### PR TITLE
SAGE-958: set the NX (core) as the primary DNS server

### DIFF
--- a/ROOTFS/media/rpi/sage-utils/dhcp-pxe/nfs/etc/resolv.conf
+++ b/ROOTFS/media/rpi/sage-utils/dhcp-pxe/nfs/etc/resolv.conf
@@ -1,2 +1,3 @@
+nameserver 10.31.81.1
 nameserver 8.8.8.8
 nameserver 8.8.4.4


### PR DESCRIPTION
NX (core) will forward DNS requests to it's upstream (DHCP issued)
server.