### PR TITLE
Sage-1049: WS2.0: remove snapd from RPi.

### DIFF
--- a/ROOTFS/media/rpi/sage-utils/dhcp-pxe/nfs/etc/rc.local
+++ b/ROOTFS/media/rpi/sage-utils/dhcp-pxe/nfs/etc/rc.local
@@ -22,6 +22,10 @@ systemctl stop apt-daily-upgrade.timer
 systemctl stop motd-news.timer
 systemctl stop man-db.timer
 
+echo "Disable snapd" | xargs -L 1 echo `date +'[%Y-%m-%d %H:%M:%S]'` >> /etc/rc.local.logs
+systemctl mask snapd.service
+systemctl stop snapd.service
+
 if [ -b "$SDDIR" ]; then
   echo "SD Card found continuing..." | xargs -L 1 echo `date +'[%Y-%m-%d %H:%M:%S]'` >> /etc/rc.local.logs
   mkdir -p /media/plugin-data/ | xargs -L 1 echo `date +'[%Y-%m-%d %H:%M:%S]'` >> /etc/rc.local.logs


### PR DESCRIPTION
1. Built the rpi .deb package
2. Copied over the new .deb package (did not setup the release but it is tagged as v2.1.5) to the nx-image
3. Modified Dockerfile.rootfs on the nx-image repo to copy the new rpi .deb package to the list of .deb packages to install.
4. Built the nx-image
5. Flashed the nx dev kit
6. Connect to WIFI to use the ethernet port to pxe-boot the rpi
7. `ps -o pid,user,%cpu,%mem,command ax | sort -b -k3 -r | grep /usr/lib/snapd/snapd | head -n1` and made sure nothing is running related to snapd.