### PR TITLE
SAGE-1155: gracefully shutdown k3s on system reboot/shutdown

### DIFF
--- a/ROOTFS/media/rpi/sage-utils/dhcp-pxe/nfs/etc/rc.local
+++ b/ROOTFS/media/rpi/sage-utils/dhcp-pxe/nfs/etc/rc.local
@@ -63,6 +63,10 @@ fi
 dpkg -i /isodebs/*
 echo "Packages In /isodebs/ Installed" | xargs -L 1 echo `date +'[%Y-%m-%d %H:%M:%S]'` >> /etc/rc.local.logs
 
+#Enable custom services
+echo "Enable custom services" | xargs -L 1 echo `date +'[%Y-%m-%d %H:%M:%S]'` >> /etc/rc.local.logs
+systemctl enable waggle-k3s-shutdown
+
 MACLower=$(sed s/://g /sys/class/net/eth0/address)
 MAC=${MACLower^^}
 MACFULL=$(printf "0000%5s\n" "$MAC")

--- a/ROOTFS/media/rpi/sage-utils/dhcp-pxe/nfs/etc/systemd/system/waggle-k3s-shutdown.service
+++ b/ROOTFS/media/rpi/sage-utils/dhcp-pxe/nfs/etc/systemd/system/waggle-k3s-shutdown.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Gracefully k3s Shutdown
+DefaultDependencies=no
+Before=shutdown.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/k3s-killall.sh
+TimeoutStartSec=0
+
+[Install]
+WantedBy=shutdown.target


### PR DESCRIPTION
This ensures /media/plugin-data is properly unmounted and file handles
(from k3s containerd) are not left open. This has the added benefit of
greatly reducing system reboot/shutdown time.